### PR TITLE
fix issue#2 (empty dependency installs)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,4 +8,10 @@
     in place using `git rebase` or `git commit --amend` to make the changes
     easier to review.
 
-3.  Open a pull request.
+3.  Run the end-to-end server tests and make sure they pass.
+
+    ```
+    make test-endtoend
+    ```
+
+4.  Open a pull request.

--- a/endtoend/server.js
+++ b/endtoend/server.js
@@ -2,20 +2,24 @@
 
 /* global after, before, describe, it */
 
+const childProcess = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const request = require('request');
+const P = require('bluebird');
 const expect = require('chai').expect;
+const request = require('request');
 
 const serverRootPath = path.join(__dirname, '..');
-
 const serverPackageJson = path.join(serverRootPath, 'package.json');
 const developmentBinaryPath = path.join(serverRootPath, 'bin/development');
 
-const spawn = require('child_process').spawn;
-const spawnSync = require('child_process').spawnSync;
+const spawn = childProcess.spawn;
+const spawnSync = childProcess.spawnSync;
 
+const requestAsync = P.promisify(request);
+
+const NPMSERVE_TEST_SERVER_ORIGIN = 'http://localhost:3000';
 const SERVER_STARTUP_PATTERN = /running with environment/;
 
 //
@@ -49,34 +53,86 @@ before((done) => {
 });
 
 after(() => {
-  console.info('shutting down the test server');
+  console.info('shutting down the test server: ', $serverProcess.pid);
   $serverProcess.kill();
 });
 
+const testServerInstall = P.promisify((packageJson, callback) => {
+  const req = {form: {packageJson: packageJson}};
+
+  request.post(NPMSERVE_TEST_SERVER_ORIGIN + '/npm/install', req)
+  .on('response', function(response) {
+    expect(response.statusCode).to.deep.equal(200);
+    expect(response.headers['content-type']).to.deep
+      .equal('application/octet-stream');
+
+    // provide a delay for piping the response to disk
+    setTimeout(() => {
+      const verifyProcess = spawnSync('gunzip',
+        ['-t', 'node_modules.tar.gz'], {cwd: serverRootPath});
+      expect(verifyProcess.status).to.deep.equal(0);
+      callback();
+    }, 3000);
+  })
+  .pipe(fs.createWriteStream('node_modules.tar.gz'));
+});
+
+const testHash = (packageJson, expectedHash) => {
+  return requestAsync({
+    uri: NPMSERVE_TEST_SERVER_ORIGIN + '/npm/hash',
+    method: 'POST',
+    body: JSON.stringify({
+      packageJson: packageJson
+    }),
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+  .then((response) => {
+    expect(response.body).to.deep.equal(expectedHash);
+    expect(response.statusCode).to.deep.equal(200);
+  });
+};
+
+const testDelete = (hash) => {
+  return requestAsync({
+    uri: NPMSERVE_TEST_SERVER_ORIGIN + '/npm/install/' + hash,
+    method: 'DELETE',
+  })
+  .then((response) => {
+    expect(response.body).to.deep.equal('build deleted');
+    expect(response.statusCode).to.deep.equal(200);
+  });
+};
+
+const PACKAGE_JSON_EMPTY = '{}';
+const PACKAGE_JSON_SERVER = JSON.stringify(require(serverPackageJson));
+const HASH_PACKAGE_JSON_EMPTY = '99914b932bd37a50b983c5e7c90ae93b';
 
 describe('npmserve-server', () => {
 
-  describe('route /npm/install', () => {
+  describe('POST /npm/hash', () => {
+    it('should return the hash of the package.json', () => {
+      return testHash(PACKAGE_JSON_EMPTY, HASH_PACKAGE_JSON_EMPTY);
+    });
+  });
 
-    it('should perform an npm install', (done) => {
-      const pjsonString = JSON.stringify(require(serverPackageJson));
-      const req = {form: {packageJson: pjsonString}};
+  describe('POST /npm/install', () => {
+    it('should perform an npm install', () => {
+      return testServerInstall(PACKAGE_JSON_SERVER);
+    });
 
-      request.post('http://localhost:3000/npm/install', req)
-      .on('response', function(response) {
-        expect(response.statusCode).to.deep.equal(200);
-        expect(response.headers['content-type']).to.deep
-          .equal('application/octet-stream');
+    it('should perform an install on an empty dependency set', () => {
+      return testServerInstall(PACKAGE_JSON_EMPTY);
+    });
+  });
 
-        // provide a delay for piping the response to disk
-        setTimeout(() => {
-          const verifyProcess = spawnSync('gunzip',
-            ['-t', 'node_modules.tar.gz'], {cwd: serverRootPath});
-          expect(verifyProcess.status).to.deep.equal(0);
-          done();
-        }, 10000);
-      })
-      .pipe(fs.createWriteStream('node_modules.tar.gz'));
+  describe('DELETE /npm/install', () => {
+    it('should delete a build from the server', () => {
+      return P.resolve()
+        .then(() => testServerInstall(PACKAGE_JSON_EMPTY))
+        .then(() => testHash(PACKAGE_JSON_EMPTY, HASH_PACKAGE_JSON_EMPTY))
+        .then(() => testDelete(HASH_PACKAGE_JSON_EMPTY));
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "morgan": "1.6.1",
     "ramda": "0.19.1",
     "request": "2.70.0",
-    "rimraf": "2.5.2",
     "serve-favicon": "2.3.0"
   },
   "devDependencies": {

--- a/util/fs.js
+++ b/util/fs.js
@@ -8,6 +8,11 @@ const mkdirp = (path) => {
   return childProcessPromise.spawn('mkdir', ['-p', path]);
 };
 
+const rmrf = (path) => {
+  return childProcessPromise.spawn('rm', ['-rf', path]);
+};
+
 module.exports = {
-  mkdirp: mkdirp
+  mkdirp: mkdirp,
+  rmrf: rmrf
 };


### PR DESCRIPTION
## summary

Fixes issue #2 (empty dependency installs cause `500` error). We now return an empty archive if user requests install of a `package.json` with no dependencies.

## testing
- Adds server end-to-end tests for the fixed test case
- Adds server end-to-end tests for the `/npm/hash` route which was previously untested.
- Adds server end-to-end tests for the `DELETE /npm/install` route which was previously untested.